### PR TITLE
Revert metrics timestamp to unixnano()

### DIFF
--- a/forwarder.go
+++ b/forwarder.go
@@ -111,9 +111,7 @@ func (fd *Forwarder) fluentBitMetricsToCloudMetrics(metrics fluentbit.Metrics) c
 	if fd.nowFunc == nil {
 		fd.nowFunc = time.Now
 	}
-
-	// TODO: change to unix nano once the Cloud API is fixed.
-	ts := fd.nowFunc().Unix()
+	ts := fd.nowFunc().UnixNano()
 
 	for metricName, metric := range metrics.Input {
 		out.Metrics = append(out.Metrics, cloud.AddMetricInput{

--- a/forwarder_test.go
+++ b/forwarder_test.go
@@ -10,10 +10,8 @@ import (
 )
 
 func Test_fluentBitMetricsToCloudMetrics(t *testing.T) {
-	now := time.Now().Truncate(time.Second)
-
-	// TODO: change to unix nano once the Cloud API is fixed.
-	ts := now.Unix()
+	now := time.Now().Truncate(time.Nanosecond)
+	ts := now.UnixNano()
 
 	tt := []struct {
 		name string


### PR DESCRIPTION
* revert metrics timestamp field to unixnano as per metric specification.
Related to https://github.com/calyptia/cloud-monitoring-api/pull/15 
Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>